### PR TITLE
[qnxlab] disable tar on Windows for qnxlab

### DIFF
--- a/src/latex/papers/qnxlab/SConscript
+++ b/src/latex/papers/qnxlab/SConscript
@@ -23,6 +23,7 @@
 Import('env')
 
 import SCons.Tool.tar
+import platform
 
 env.Tool('texas')
 
@@ -42,7 +43,9 @@ version = '0.1'
 pdf = env.TeXASPDF(name, '%s.tex' % name, pdf_deps = deps, version = version)
 
 # Tar is unavailable on some platforms (windows e.g) ...
-if SCons.Tool.tar.exists(env):
+# On mingw/windows (BASH CLI for example) it has a bug with commandline paths
+# handling (e.g. 'a\t' is interpreted as a + tab).
+if SCons.Tool.tar.exists(env) and not platform.system() == 'Windows':
     src = env.TeXASChildren(pdf)
     tgz = env.TeXASTarGz(name, src, strip_dirs = '..', version = version)
 else:


### PR DESCRIPTION
It looks like tar doesn't handle paths provided via CLI properly, for example it will not accept `foo\cez\tar` saying that `foo\\cez\tar` canoot be found (note the single backslash `\` before `tar`). It looks like it interprets `\t` as an escape sequence for tab character. Similarly for other special characters (\b,\v,...).

This happens at least on mingw (git bash) under Windows 10.
