### PR TITLE
add support for --repository flag in bin/install-tex.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
     else
       echo "$HOME/TeXLive2015/bin/x86_64-linux DOES NOT EXIST";
     fi
-  - python bin/install-tex.py
+  - python bin/install-tex.py --repository="http://ctan.math.washington.edu/tex-archive/systems/texlive/tlnet"
   - PATH="$HOME/TeXLive2015/bin/x86_64-linux:$PATH"
 
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
   - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - easy_install scons
   - python bin\downloads.py
-  - python bin\install-tex.py
+  - python bin\install-tex.py --repository="http://ctan.math.washington.edu/tex-archive/systems/texlive/tlnet"
   - SET "PATH=%USERPROFILE%\\TeXLive2015\\bin\\win32;%PATH%"
 
 # Sorry, but our cache would exceed 500MB, and appveyor treats caching

--- a/bin/install-tex.py
+++ b/bin/install-tex.py
@@ -130,11 +130,19 @@ def install_texlive(**kw):
     else:
         raise RuntimeError("unsuported OS %s" % platform.system())
 
+    repository = kw.get('repository')
+
     profile = os.path.join(tempdir, 'texlive.profile')
     
-    info("starting TeX installer", **kw)
-    sp = subprocess.Popen([cmd, '-profile', profile], env = os.environ.copy(), stdin = subprocess.PIPE)
+    args = [cmd, '-profile', profile]
+    if repository:
+        args += ['-repository', repository]
+
+    info("starting TeX instaler", **kw)
+    info("%s" % map(lambda x : str(x), args), **kw)
+    sp = subprocess.Popen(args, env = os.environ.copy(), stdin = subprocess.PIPE)
     if platform.system() == 'Windows':
+        # Answer to "Press any key to continue..."
         sp.stdin.write("\r\n")
     sp.stdin.close()
     sp.wait()
@@ -185,6 +193,7 @@ _parser.add_argument('--installer-url',
                       help='url used to retrieve TeX installer from')
 _parser.add_argument('--profile',
                       help='path to texlive profile for unattended installation')
+_parser.add_argument('--repository', help='path/url to package repository')
 
 _args = _parser.parse_args()
 main(**vars(_args))


### PR DESCRIPTION
Two things done here:
- added --repository CLI option to bin/install-tex.py
- configured travis-ci and appveyor to use fast TeXLive mirror
