### PR TITLE
use texlive cache on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ install:
       echo "$HOME/TeXLive2015/bin/x86_64-linux EXISTS";
     else
       echo "$HOME/TeXLive2015/bin/x86_64-linux DOES NOT EXIST";
+      python bin/install-tex.py --repository="http://ctan.math.washington.edu/tex-archive/systems/texlive/tlnet";
     fi
-  - python bin/install-tex.py --repository="http://ctan.math.washington.edu/tex-archive/systems/texlive/tlnet"
   - PATH="$HOME/TeXLive2015/bin/x86_64-linux:$PATH"
 
 before_script:


### PR DESCRIPTION
This PR makes real use of cached TeXLive installation on Travis-CI, such that it mostly doesn't have to be downloaded and installed.
