### PR TITLE
[qnxlab] change fonts in code snippets to truetype

### DIFF
--- a/src/latex/papers/qnxlab/qnxlab.tex
+++ b/src/latex/papers/qnxlab/qnxlab.tex
@@ -108,7 +108,7 @@ postheadspace=1em,
 \lstdefinestyle{MyCStyle} {
     language=C, % choose the language of the code
     alsolanguage=C++,
-    basicstyle=\linespread{0.9}\fontfamily{lmss}\selectfont\small\color{black},
+    basicstyle=\linespread{0.9}\fontfamily{lmtt}\selectfont\small\color{black},
     keywordstyle={\bfseries\color{syntax}}, % style for keywords
     emph={int,char,double,float,unsigned,printf,getchar,putchar,
 sprintf,scanf,fopen,fscanf,fprintf,fclose,pthread_self,pthread_create,sleep,exit,pthread_t,
@@ -123,7 +123,7 @@ pthread_barrier_init, pthread_barrier_t,pthread_barrierattr_t,pthread_barrier_wa
 pthread_cond_t,pthread_mutexattr_t,pthread_condattr_t},
     emphstyle={\bfseries\color{syntax}},
     stringstyle=\color{strings},
-    commentstyle={\fontfamily{lmss}\selectfont\color{comments}},
+    commentstyle={\fontfamily{lmtt}\selectfont\color{comments}},
     numbers=left, % where to put the line-numbers
     numberstyle=\tiny, % the size of the fonts that are used for the line-numbers
     backgroundcolor=\color{lemonchiffon},
@@ -153,12 +153,12 @@ pthread_cond_t,pthread_mutexattr_t,pthread_condattr_t},
 
 \lstdefinestyle{MyBashStyle} {
     language=bash, % choose the language of the code
-    basicstyle=\linespread{0.9}\fontfamily{lmss}\selectfont\small\color{black},
+    basicstyle=\linespread{0.9}\fontfamily{lmtt}\selectfont\small\color{black},
     keywordstyle={\color{black}}, % style for keywords
     emph={},
     emphstyle={\color{black}},
     stringstyle=\color{black},
-    commentstyle={\fontfamily{lmss}\selectfont\color{black}},
+    commentstyle={\fontfamily{lmtt}\selectfont\color{black}},
     numbers=left, % where to put the line-numbers
     numberstyle=\tiny, % the size of the fonts that are used for the line-numbers
     backgroundcolor=\color{lemonchiffon},


### PR DESCRIPTION
Code samples should use truetype fonts. This is a standard practice!
